### PR TITLE
Upgrade to casperjs 1.0.0-RC4 and PhantomJS 1.7  and fix executable permissions issues

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+*.pyc
+bin/
+develop-eggs/
+gp.recipe.phantomjs.egg-info/
+.installed.cfg

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,9 @@
+1.4
+===
+
+* Upgrade to casperjs 1.0.0-RC4 and PhantomJS 1.7 
+* Fix executable permissions issues
+
 1.3
 ===
 

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(*rnames):
     except:
         return ''
 
-version = '1.3'
+version = '1.4'
 
 long_description = (
     read('README.txt')


### PR DESCRIPTION
- Upgrade to casperjs 1.0.0-RC4 and PhantomJS 1.7 
- Fix executable permissions issues
