### PR TITLE
Use own mirror of PhantomJS

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,7 @@
-(next version)
-==============
+1.9.1
+=====
 
+* Switch to PhantomJS 1.9.1
 * Add phantomjs-url-base option for using phantomjs mirrors.
 
 1.9.0.2

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,3 +1,8 @@
+(next version)
+==============
+
+* Add phantomjs-url-base option for using phantomjs mirrors.
+
 1.9.0.2
 ========
 

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,1 +1,2 @@
 - Gael Pasgrimaud
+- Richard Barrell

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,11 @@ The recipe supports the following options:
 phantomjs-url
     Url to download phantomjs
 
+phantomjs-url-base
+    If phantomjs-url is not specified, this recipe downloads phantomjs from
+    phantomjs-url-base. Defaults to https://phantomjs.googlecode.com/files/
+    Set this if you want to use your own mirror for phantomjs.
+
 phantomjs-version
     Try to retreive phantomjs url from version
 

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -42,22 +42,21 @@ class Recipe(object):
             url = self.options.get('phantomjs-url', None)
             if not url:
                 version = self.options.get('phantomjs-version', '1.7.0')
+                default_base = 'https://phantomjs.googlecode.com/files'
+                url_base = self.options.get('phantomjs-url-base', default_base)
                 if sys.platform.startswith('linux'):
                     arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
                     url = (
-                        'https://phantomjs.googlecode.com/'
-                        'files/phantomjs-%s-linux-%s.tar.bz2'
-                    ) % (version, arch)
+                        '%s/phantomjs-%s-linux-%s.tar.bz2'
+                    ) % (url_base, version, arch)
                 elif sys.platform == 'darwin':
                     url = (
-                        'https://phantomjs.googlecode.com/'
-                        'files/phantomjs-%s-macosx.zip'
-                    ) % version
+                        '%s/phantomjs-%s-macosx.zip'
+                    ) % (url_base, version)
                 elif sys.platform.startswith('win'):
                     url = (
-                        'https://phantomjs.googlecode.com/'
-                        'files/phantomjs-%s-windows.zip'
-                    ) % version
+                        '%s/phantomjs-%s-windows.zip'
+                    ) % (url_base, version)
                 else:
                     raise RuntimeError('Please specify a phantomjs-url')
             self.download(url)

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -41,7 +41,7 @@ class Recipe(object):
         if 'phantomjs' not in binaries:
             url = self.options.get('phantomjs-url', None)
             if not url:
-                version = self.options.get('phantomjs-version', '1.7.0')
+                version = self.options.get('phantomjs-version', '1.9.1')
                 default_base = 'https://phantomjs.googlecode.com/files'
                 url_base = self.options.get('phantomjs-url-base', default_base)
                 if sys.platform.startswith('linux'):

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ def read(*rnames):
     except:
         return ''
 
-version = '1.9.0.2'
+version = '1.9.1.0'
 
 long_description = (
     read('README.rst')


### PR DESCRIPTION
Addresses https://github.com/gawel/gp.recipe.phantomjs/issues/12

Also I couldn't resist bumping PhantomJS version to 1.9.1 in there while I was at it.
CHANGES.txt previously claimed that 1.9.0 was the default, but the **init**.py actually defaulted to 1.7.0.
