### PR TITLE
Adding fix to allow gp.recipe.phantomjs to honor relative-paths buildout option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ gp.recipe.phantomjs.egg-info/
 .installed.cfg
 eggs
 parts
+*.egg
+*~

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,5 +6,6 @@ python:
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: python bootstrap.py; bin/buildout
 
+
 # command to run tests, e.g. python setup.py test
 script: ./bin/python setup.py test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+  - "2.6"
+  - "3.3"
+# command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
+install: python bootstrap.py; bin/buildout
+
+# command to run tests, e.g. python setup.py test
+script: ./bin/python setup.py test

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,9 +1,14 @@
 [buildout]
 develop = .
-parts = casperjs
+parts = casperjs python
 
 [casperjs]
 recipe = gp.recipe.phantomjs
 
 [tox]
 recipe = gp.recipe.tox
+
+[python]
+recipe = zc.recipe.egg
+interpreter = python
+eggs = gp.recipe.phantomjs

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -99,7 +99,7 @@ class Recipe(object):
     def _get_relative_binary_dict(self, binaries):
         """ convert absolute paths to relative arguments """
         dict_items = ("'{0}': {1}".format(name, self._to_relative(path))
-                      for name, path in binaries.items())
+                      for name, path in sorted(binaries.items()))
         return "{{{0}}}".format(", ".join(dict_items))
 
     def _to_relative(self, absolute_path):

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -13,6 +13,7 @@ class Recipe(object):
         self.install_dir = os.path.join(
             buildout['buildout']['parts-directory'], name
         )
+        self.relative_paths = self.buildout['buildout'].get('relative-paths', False)
 
     def get_version(self, options):
         version = options.get('phantomjs-version')
@@ -80,8 +81,11 @@ class Recipe(object):
         binaries = self.get_binaries()
         for f in binaries.values():
             os.chmod(f, 0o777)
-
-        self.options['arguments'] = repr(binaries)
+            
+        if self.relative_paths:
+            self.options['arguments'] = self._get_relative_binary_dict(binaries)
+        else:
+            self.options['arguments'] = repr(binaries)
         self.options['eggs'] = 'gp.recipe.phantomjs'
         self.options['entry-points'] = '\n'.join([
             '%s=gp.recipe.phantomjs.script:main' % s for s in binaries
@@ -91,3 +95,14 @@ class Recipe(object):
         return rscripts.install()
 
     update = install
+
+    def _get_relative_binary_dict(self, binaries):
+        """ convert absolute paths to relative arguments """
+        dict_items = ("'{0}': {1}".format(name, self._to_relative(path))
+                      for name, path in binaries.items())
+        return "{{{0}}}".format(", ".join(dict_items))
+
+    def _to_relative(self, absolute_path):
+        """ convert an absolute path to a relative one """
+        path = absolute_path.replace(self.install_dir, '').lstrip(os.sep)
+        return "join(base, 'parts', '{0}', '{1}')".format(self.name, path)

--- a/gp/recipe/phantomjs/tests/test_init.py
+++ b/gp/recipe/phantomjs/tests/test_init.py
@@ -1,0 +1,41 @@
+import unittest
+import os
+from mock import patch 
+from gp.recipe.phantomjs import Recipe
+
+PARTS_DIRECTORY = "this_is_a_dummy"
+
+
+class TestPhantomjs(unittest.TestCase):
+
+    def setUp(self):
+        self.name = 'test'
+        self.buildout = {
+            'buildout': {
+                'parts-directory': PARTS_DIRECTORY,
+                'relative-paths': 'true'
+            }
+        }
+        self.install_dir = os.path.join(PARTS_DIRECTORY, self.name)
+        self.options = {}
+        self.recipe = Recipe(self.buildout, self.name, self.options)
+
+    def test_to_relative(self):
+        """ _to_relative should generate a buildout relative path """
+        test_path = os.path.join('mytest', 'me')
+        absolute_test_path = os.path.join(self.install_dir, test_path)
+        result = self.recipe._to_relative(absolute_test_path)
+        assert result == "join(base, 'parts', '{0}', '{1}')".format(
+            self.name,
+            test_path
+        )
+
+    def test_get_relative_binary_dict(self):
+        """ _get_relative_binary_dict should return a valid relative dictionary """
+        binaries = {
+            'phantomjs': os.path.join(self.install_dir, 'phantomFoo'),
+            'casperjs': os.path.join(self.install_dir, 'casperBar')
+        }
+        result = self.recipe._get_relative_binary_dict(binaries)
+        assert (result ==
+                "{'casperjs': join(base, 'parts', 'test', 'casperBar'), 'phantomjs': join(base, 'parts', 'test', 'phantomFoo')}")

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ long_description = (
 entry_point = 'gp.recipe.phantomjs:Recipe'
 entry_points = {"zc.buildout": ["default = %s" % entry_point]}
 
-tests_require = ['zope.testing', 'zc.buildout']
+tests_require = ['zope.testing', 'zc.buildout', 'Mock']
 
 setup(name='gp.recipe.phantomjs',
       version=version,
@@ -52,7 +52,7 @@ setup(name='gp.recipe.phantomjs',
       url='http://github.com/gawel/gp.recipe.phantomjs',
       license='gpl',
       packages=find_packages(exclude=['ez_setup', 'tests',
-                                      'bootstrap', 'bootstrap-py3k']),
+                                      'bootstrap']),
       namespace_packages=['gp', 'gp.recipe'],
       include_package_data=True,
       zip_safe=False,
@@ -63,6 +63,6 @@ setup(name='gp.recipe.phantomjs',
                         ],
       tests_require=tests_require,
       extras_require=dict(tests=tests_require),
-      test_suite='gp.recipe.phantomjs.tests.test_docs.test_suite',
+      test_suite='gp.recipe.phantomjs.tests',
       entry_points=entry_points,
       )


### PR DESCRIPTION
In buildout, there's an options "relative-paths" that allows the built-out files to be moved to a different directory:
https://pypi.python.org/pypi/zc.buildout/2.2.1#relative-paths

This is a fix to make sure gp.recipe.phantomjs honors relative pathing.

I also added a few tests to unit test my new functionality. Also added a travis.yml file to check my changes:
https://travis-ci.org/toumorokoshi/gp.recipe.phantomjs.

I wasn't sure how to run tests.py, so I couldn't add it to the travis.yml file.

I'm sorry about the big patch, but this is a significant change and wanted to ensure my code worked as desired.
