### PR TITLE
Adding phantomjs-url-template option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ eggs
 parts
 *.egg
 *~
+.tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 python:
   - "2.7"
   - "2.6"
-  - "3.3"
+  - "3.4"
 # command to install dependencies, e.g. pip install -r requirements.txt --use-mirrors
 install: python bootstrap.py; bin/buildout
 

--- a/README.rst
+++ b/README.rst
@@ -17,8 +17,20 @@ phantomjs-url
 
 phantomjs-url-base
     If phantomjs-url is not specified, this recipe downloads phantomjs from
-    phantomjs-url-base. Defaults to https://phantomjs.googlecode.com/files/
+    phantomjs-url-base. Defaults to https://bitbucket.org/ariya/phantomjs/downloads/.
     Set this if you want to use your own mirror for phantomjs.
+
+phantomjs-url-template
+    If phantomjs-url and phantomjs-url-template are
+    not set, you can set a template which will populate various
+    variables. The variables should be wrapped in {}, and the
+    following values are supported:
+
+    * arch: the architecture. x86_64 or i686
+    * phantom_platform: the platform, following the format dictated by the standard phantomjs url (e.g. linux, macosx)
+    * phantom_extension: the extension, as specified by the format dictated by the standard phantomjs url (e.g. tar.bz2, zip)
+    * platform: the platform, as specified by sys.platform (e.g. linux, darwin)
+    * version: the version of phantomjs
 
 phantomjs-version
     Try to retreive phantomjs url from version
@@ -47,4 +59,3 @@ We'll start by creating a buildout that uses the recipe::
     -  buildout
     -  casperjs
     -  phantomjs
-

--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,7 @@ phantomjs-url-base
 
 phantomjs-url-template
     If phantomjs-url and phantomjs-url-template are
-    not set, you can set a template which will populate various
+    not specified, you can set a template which will populate various
     variables. The variables should be wrapped in {}, and the
     following values are supported:
 

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,6 @@
 Buildout recipe to install phantomjs/casperjs
 
+
 Supported options
 =================
 

--- a/README.rst
+++ b/README.rst
@@ -33,6 +33,11 @@ phantomjs-url-template
     * platform: the platform, as specified by sys.platform (e.g. linux, darwin)
     * version: the version of phantomjs
 
+    The default template is:
+
+        https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-{version}-{phantom_platform}.{phantom_extension}
+
+
 phantomjs-version
     Try to retreive phantomjs url from version
 

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -12,3 +12,5 @@ recipe = gp.recipe.tox
 recipe = zc.recipe.egg
 interpreter = python
 eggs = gp.recipe.phantomjs
+       nose
+       mock

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -101,7 +101,7 @@ class Recipe(object):
         if 'phantomjs' not in binaries:
             if self.options.get('phantomjs-url', None):
                 url = self.options.get('phantomjs-url')
-            elif self.get.options('phantomjs-url-base', None):
+            elif self.options.get('phantomjs-url-base', None):
                 url = self._get_url_from_base()
             else:
                 url = self._get_url_from_template()

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -68,10 +68,12 @@ class Recipe(object):
             'arch': arch,
             'phantom_platform': phantom_platform,
             'phantom_extension': phantom_extension,
+            'platform': self.platform,
             'version': self.get_version(self.options)
         }
 
-        return DEFAULT_URL_TEMPLATE.format(**template_dict)
+        url_template = self.options.get('phantomjs-url-template', DEFAULT_URL_TEMPLATE)
+        return url_template.format(**template_dict)
 
     def install(self):
         """Installer"""

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -49,6 +49,26 @@ class Recipe(object):
         dl = Download(self.buildout, self.name, options)
         dl.install()
 
+    def _get_url_from_base(self):
+        version = self.get_version(self.options)
+        url_base = self.options.get('phantomjs-url-base', None)
+        if sys.platform.startswith('linux'):
+            arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
+            url = (
+                '%s/phantomjs-%s-linux-%s.tar.bz2'
+            ) % (url_base, version, arch)
+        elif sys.platform == 'darwin':
+            url = (
+                '%s/phantomjs-%s-macosx.zip'
+            ) % (url_base, version)
+        elif sys.platform.startswith('win'):
+            url = (
+                '%s/phantomjs-%s-windows.zip'
+            ) % (url_base, version)
+        else:
+            raise RuntimeError('Please specify a phantomjs-url')
+        return url
+
     def _get_url_from_template(self):
         arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
         if sys.platform == 'darwin':
@@ -79,8 +99,11 @@ class Recipe(object):
         """Installer"""
         binaries = self.get_binaries()
         if 'phantomjs' not in binaries:
-            url = self.options.get('phantomjs-url', None)
-            if not url:
+            if self.options.get('phantomjs-url', None):
+                url = self.options.get('phantomjs-url')
+            elif self.get.options('phantomjs-url-base', None):
+                url = self._get_url_from_base()
+            else:
                 url = self._get_url_from_template()
             self.download(url)
         if 'casperjs' not in binaries:

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -88,7 +88,7 @@ class Recipe(object):
             'arch': arch,
             'phantom_platform': phantom_platform,
             'phantom_extension': phantom_extension,
-            'platform': self.platform,
+            'platform': sys.platform,
             'version': self.get_version(self.options)
         }
 

--- a/gp/recipe/phantomjs/tests/test_init.py
+++ b/gp/recipe/phantomjs/tests/test_init.py
@@ -14,7 +14,8 @@ class TestPhantomjs(unittest.TestCase):
         self.buildout = {
             'buildout': {
                 'parts-directory': PARTS_DIRECTORY,
-                'relative-paths': 'true'
+                'relative-paths': 'true',
+                'version': '1.9.7'
             }
         }
         self.install_dir = os.path.join(PARTS_DIRECTORY, self.name)
@@ -45,9 +46,9 @@ class TestPhantomjs(unittest.TestCase):
         """ _get_url_from_template should return the proper url """
         url = None
         if sys.platform == 'darwin':
-            url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-macosx.zip'
+            url = 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-macosx.zip'
         elif sys.platform == 'linux':
             arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
-            url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-linux-' + arch + '.tar.bz2'
+            url = 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-' + arch + '.tar.bz2'
         if url:
             assert self.recipe._get_url_from_template() == url

--- a/gp/recipe/phantomjs/tests/test_init.py
+++ b/gp/recipe/phantomjs/tests/test_init.py
@@ -1,6 +1,7 @@
 import unittest
 import os
-from mock import patch 
+import sys
+from mock import patch
 from gp.recipe.phantomjs import Recipe
 
 PARTS_DIRECTORY = "this_is_a_dummy"
@@ -39,3 +40,12 @@ class TestPhantomjs(unittest.TestCase):
         result = self.recipe._get_relative_binary_dict(binaries)
         assert (result ==
                 "{'casperjs': join(base, 'parts', 'test', 'casperBar'), 'phantomjs': join(base, 'parts', 'test', 'phantomFoo')}")
+
+    def test_get_url_from_template(self):
+        """ _get_url_from_template should return the proper url """
+        if sys.platform == 'darwin':
+            url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-macosx.zip'
+        elif sys.platform == 'linux':
+            arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
+            url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-linux-' + arch + '.zip'
+        assert self.recipe._get_url_from_template() == url

--- a/gp/recipe/phantomjs/tests/test_init.py
+++ b/gp/recipe/phantomjs/tests/test_init.py
@@ -48,6 +48,6 @@ class TestPhantomjs(unittest.TestCase):
             url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-macosx.zip'
         elif sys.platform == 'linux':
             arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
-            url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-linux-' + arch + '.zip'
+            url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-linux-' + arch + '.tar.bz2'
         if url:
             assert self.recipe._get_url_from_template() == url

--- a/gp/recipe/phantomjs/tests/test_init.py
+++ b/gp/recipe/phantomjs/tests/test_init.py
@@ -43,9 +43,11 @@ class TestPhantomjs(unittest.TestCase):
 
     def test_get_url_from_template(self):
         """ _get_url_from_template should return the proper url """
+        url = None
         if sys.platform == 'darwin':
             url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-macosx.zip'
         elif sys.platform == 'linux':
             arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
             url = 'https://bitbucket.org/ariya/downloads/phantomjs-1.9.7-linux-' + arch + '.zip'
-        assert self.recipe._get_url_from_template() == url
+        if url:
+            assert self.recipe._get_url_from_template() == url

--- a/tox.ini
+++ b/tox.ini
@@ -11,6 +11,7 @@ commands =
 deps =
     zc.buildout
     nose
+    mock
 
 [testenv:py27]
 basepython=python2.7
@@ -22,6 +23,7 @@ commands =
 deps =
     zc.buildout
     nose
+    mock
 
 [testenv:py33]
 basepython=python3.3
@@ -33,3 +35,4 @@ commands =
 deps =
     zc.buildout
     nose
+    mock

--- a/tox.ini
+++ b/tox.ini
@@ -25,8 +25,8 @@ deps =
     nose
     mock
 
-[testenv:py33]
-basepython=python3.3
+[testenv:py34]
+basepython=python3.4
 changedir={toxinidir}
 commands =
     rm -Rf .installed.cfg {envdir}/parts


### PR DESCRIPTION
It would be nice to have an option phantomjs-url-template, that allows one to use a template instead of a url base (in case we have to upload to a repository system that doesn't provide the same file format as phantomjs does).

Here's the snippet from the readme:

```
phantomjs-url-template
    If phantomjs-url and phantomjs-url-template are
    not specified, you can set a template which will populate various
    variables. The variables should be wrapped in {}, and the
    following values are supported:

    * arch: the architecture. x86_64 or i686
    * phantom_platform: the platform, following the format dictated by the standard phantomjs url (e.g. linux, macosx)
    * phantom_extension: the extension, as specified by the format dictated by the standard phantomjs url (e.g. tar.bz2, zip)
    * platform: the platform, as specified by sys.platform (e.g. linux, darwin)
    * version: the version of phantomjs

    The default template is:

        https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-{version}-{phantom_platform}.{phantom_extension}
```
