### PR TITLE
Normalizing sys.platform

### DIFF
--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -1,2 +1,3 @@
 - Gael Pasgrimaud
 - Richard Barrell
+- Yusuke Tsutsumi

--- a/README.rst
+++ b/README.rst
@@ -30,7 +30,7 @@ phantomjs-url-template
     * arch: the architecture. x86_64 or i686
     * phantom_platform: the platform, following the format dictated by the standard phantomjs url (e.g. linux, macosx)
     * phantom_extension: the extension, as specified by the format dictated by the standard phantomjs url (e.g. tar.bz2, zip)
-    * platform: the platform, as specified by sys.platform (e.g. linux, darwin)
+    * platform: the platform, which is one of: linux, darwin, or windows
     * version: the version of phantomjs
 
     The default template is:

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,5 @@
 Buildout recipe to install phantomjs/casperjs
 
-
 Supported options
 =================
 

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -74,13 +74,16 @@ class Recipe(object):
         if sys.platform == 'darwin':
             phantom_platform = 'macosx'
             phantom_extension = 'zip'
+            platform = 'darwin'
         elif sys.platform.startswith('win'):
             phantom_platform = 'windows'
             phantom_extension = 'zip'
+            platform = 'windows'
         # else we assume linux
         elif sys.platform.startswith('linux'):
             phantom_platform = 'linux-{0}'.format(arch)
             phantom_extension = 'tar.bz2'
+            platform = 'linux'
         else:
             raise RuntimeError('Please specify a phantomjs-url')
 
@@ -88,7 +91,7 @@ class Recipe(object):
             'arch': arch,
             'phantom_platform': phantom_platform,
             'phantom_extension': phantom_extension,
-            'platform': sys.platform,
+            'platform': platform,
             'version': self.get_version(self.options)
         }
 

--- a/gp/recipe/phantomjs/__init__.py
+++ b/gp/recipe/phantomjs/__init__.py
@@ -69,7 +69,7 @@ class Recipe(object):
             raise RuntimeError('Please specify a phantomjs-url')
         return url
 
-    def _get_url_from_template(self):
+    def _generate_template_dict(self):
         arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
         if sys.platform == 'darwin':
             phantom_platform = 'macosx'
@@ -87,7 +87,7 @@ class Recipe(object):
         else:
             raise RuntimeError('Please specify a phantomjs-url')
 
-        template_dict = {
+        return {
             'arch': arch,
             'phantom_platform': phantom_platform,
             'phantom_extension': phantom_extension,
@@ -95,6 +95,8 @@ class Recipe(object):
             'version': self.get_version(self.options)
         }
 
+    def _get_url_from_template(self):
+        template_dict = self._generate_template_dict()
         url_template = self.options.get('phantomjs-url-template', DEFAULT_URL_TEMPLATE)
         return url_template.format(**template_dict)
 

--- a/gp/recipe/phantomjs/tests/test_init.py
+++ b/gp/recipe/phantomjs/tests/test_init.py
@@ -54,3 +54,31 @@ class TestPhantomjs(unittest.TestCase):
             url = 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-windows.zip'
         if url:
             assert self.recipe._get_url_from_template() == url
+
+    def test_generate_template_dict(self):
+        """ _generate_template_dict should return the proper values """
+        arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
+        if sys.platform == 'darwin':
+            assert self.recipe._generate_template_dict() == {
+                'arch': arch,
+                'phantom_platform': 'macosx',
+                'phantom_extension': 'zip',
+                'platform': 'darwin',
+                'version': '1.9.7'
+            }
+        elif sys.platform.startswith('win'):
+            assert self.recipe._generate_template_dict() == {
+                'arch': arch,
+                'phantom_platform': 'windows',
+                'phantom_extension': 'zip',
+                'platform': 'windows',
+                'version': '1.9.7'
+            }
+        elif sys.platform.startswith('linux'):
+            assert self.recipe._generate_template_dict() == {
+                'arch': arch,
+                'phantom_platform': 'linux-{0}'.format(arch),
+                'phantom_extension': 'tar.bz2',
+                'platform': 'linux',
+                'version': '1.9.7'
+            }

--- a/gp/recipe/phantomjs/tests/test_init.py
+++ b/gp/recipe/phantomjs/tests/test_init.py
@@ -47,8 +47,10 @@ class TestPhantomjs(unittest.TestCase):
         url = None
         if sys.platform == 'darwin':
             url = 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-macosx.zip'
-        elif sys.platform == 'linux':
+        elif sys.platform.startswith('linux'):
             arch = 'x86_64' in os.uname() and 'x86_64' or 'i686'
             url = 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-linux-' + arch + '.tar.bz2'
+        elif sys.platform.startswith('win'):
+            url = 'https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-1.9.7-windows.zip'
         if url:
             assert self.recipe._get_url_from_template() == url


### PR DESCRIPTION
As of Python3, platform names are normalized a bit more than they are in Python2. linux2, linux3 are reduced to linux. This pull request normalizes the {platform} template variable in a similar way, reducing the platform to one of : linux, darwin, and windows.
